### PR TITLE
Simplify npm scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,9 +4,9 @@
   "version": "0.0.4",
   "description": "Simple client/server A/B testing framework",
   "scripts": {
-    "build": "./node_modules/.bin/coffee -o lib -c src/*.coffee",
-    "test": "./node_modules/.bin/jasmine-node jasmine-node --coffee spec/*.spec.coffee --verbose",
-    "prepublish": "./node_modules/.bin/coffee -o lib -c src/*.coffee"
+    "build": "coffee -o lib -c src/*.coffee",
+    "test": "jasmine-node --coffee spec/*.spec.coffee --verbose",
+    "prepublish": "coffee -o lib -c src/*.coffee"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Double `jasmine-node` in `npm test` was giving me trouble.  Got rid of `./node_modules/.bin` prefixes while I was in there.  Npm includes `/node_modules/.bin` in the `$PATH` for scripts [by default](https://www.npmjs.org/doc/misc/npm-scripts.html#path).  Gathered from an old [substack post](http://substack.net/task_automation_with_npm_run#the-scripts-field).
