### PR TITLE
Test the use of stores

### DIFF
--- a/spec/experiment.spec.coffee
+++ b/spec/experiment.spec.coffee
@@ -1,4 +1,5 @@
 Experiment = require '../src/experiment'
+MemoryStore = require '../src/memory_store'
 
 describe 'Experiment', ->
   {experiment, variant} = {}
@@ -52,5 +53,48 @@ describe 'Experiment', ->
         expect(experiment.chosen.name).toBe "peter_rabbit"
         expect(experiment.chosen.value).toEqual "gray"
 
+    describe 'when the experiment has a store', ->
+      {store} = {}
+
+      beforeEach ->
+        store = new MemoryStore()
+        experiment.store = store
+        experiment.variant "peter_rabbit", "gray"
+        experiment.run()
+
+      it 'saves the chosen variant in the store', ->
+        expect(store.get('fluffy_bunnies')).toBe experiment.chosen.name
+
+    describe 'called multiple times', ->
+      {uniqueVariants} = {}
+
+      beforeEach ->
+        experiment.variant "cotton_tail", 50, "white"
+        experiment.variant "peter_rabbit", 50, "gray"
+
+      run100Times = ->
+        [1..100]
+          .map(-> experiment.run().name)
+          .reduce (uniqueVariants, variantName) ->
+            uniqueVariants.push(variantName) unless uniqueVariants.indexOf(variantName) > -1
+            uniqueVariants
+          , []
+
+      describe 'without a store', ->
+        beforeEach ->
+          uniqueVariants = run100Times()
+
+        it 'returns a random variant each time', ->
+          expect(uniqueVariants.length).toBeGreaterThan 1
+
+      describe 'with a store', ->
+        beforeEach ->
+          store = new MemoryStore()
+          store.addResult experiment.name, 'cotton_tail'
+          experiment.store = store
+          uniqueVariants = run100Times()
+
+        it 'always returns the stored value', ->
+          expect(uniqueVariants).toEqual ['cotton_tail']
 
 

--- a/spec/laboratory.spec.coffee
+++ b/spec/laboratory.spec.coffee
@@ -1,4 +1,5 @@
 Laboratory = require '../src/laboratory'
+MemoryStore = require '../src/memory_store'
 
 describe 'Laboratory', ->
   {laboratory} = {}
@@ -44,4 +45,14 @@ describe 'Laboratory', ->
     describe 'on undefined experiment', ->
       it 'returns undefined', ->
         expect(laboratory.run('somethingThatDoesNotExist')).toBeFalsy()
+
+  describe 'given a store', ->
+    {store} = {}
+
+    beforeEach ->
+      store = new MemoryStore()
+      laboratory = new Laboratory(store)
+
+    it 'passes the store to all experiments', ->
+      expect(laboratory.addExperiment("addToOrder").store).toBe store
 

--- a/src/experiment.coffee
+++ b/src/experiment.coffee
@@ -12,7 +12,7 @@ class Experiment
 
   run: ->
     if (variantName = @store?.get(@name))?
-      @chosen = _(@_variants).find (v) -> v.name is variantName
+      [@chosen] = @_variants.filter (v) -> v.name is variantName
       if @chosen?
         @chosen.value?()
     else

--- a/src/memory_store.coffee
+++ b/src/memory_store.coffee
@@ -1,0 +1,11 @@
+# A simple reference Store implementation
+
+module.exports = class MemoryStore
+  constructor: ->
+    @results = {}
+
+  get: (experimentName) ->
+    @results[experimentName]
+
+  addResult: (experimentName, chosenVariantName) ->
+    @results[experimentName] = chosenVariantName


### PR DESCRIPTION
Adds some tests around using stores with experiments and laboratories.  Discovered missing `_` dependency in `Experiment`.  Opted to remove the dependency rather than include underscore, but not attached to that direction.  

Also includes a reference store implementation used in tests.
